### PR TITLE
flake8: allow 120 chars on a line

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
Several lines already go over 80 and 80 is a bit restrictive anyway.